### PR TITLE
update base container and ZK version to eliminate security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM java:openjdk-7-jdk
+FROM openjdk:8-jdk-slim
 MAINTAINER support@mesosphere.io
 
 # Update java settings so DNS changes take hold.
-RUN grep '^networkaddress.cache.ttl=' /etc/java-7-openjdk/security/java.security || echo 'networkaddress.cache.ttl=60' >> /etc/java-7-openjdk/security/java.security
+RUN apt-get update && apt-get install -y --no-install-recommends curl
+RUN grep '^networkaddress.cache.ttl=' /etc/java-8-openjdk/security/java.security || echo 'networkaddress.cache.ttl=60' >> /etc/java-8-openjdk/security/java.security
 
 RUN \
     # Install zookeeper
-    curl -Lo /tmp/zookeeper.tgz http://apache.osuosl.org/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz \
+    curl -Lo /tmp/zookeeper.tgz http://apache.osuosl.org/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz \
     && mkdir -p /opt/zookeeper/transactions /opt/zookeeper/snapshots \
     && tar -xzf /tmp/zookeeper.tgz -C /opt/zookeeper --strip=1 \
     && rm /tmp/zookeeper.tgz \


### PR DESCRIPTION
This changes the base container to a slim (and up to date) image and bumps the ZK version to eliminate the security vulnerabilities that CFPB reported